### PR TITLE
Prepare 0.1.8 with startup updates and provider inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.8 — 2026-08-26
+
+### Changed
+- Automatic update checks now run whenever the RepoTracer MCP server starts instead of at most once every 24 hours
+- Isolated Codex scouts preserve the active built-in or custom model provider, provider authentication mode, and credential store without inheriting personal MCP servers, hooks, plugins, or instructions
+
 ## 0.1.7 — 2026-08-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "repotracer"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "repotracer-bench"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "repotracer-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "repotracer-mcp"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "repotracer-model"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "repotracer-repo-tools"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 default-members = ["crates/cli"]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/repotracer/repotracer"

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ repotracer update
 
 1. The installed routing instructions tell Codex when an unfamiliar or cross-file task needs repository exploration.
 2. Codex calls the MCP tool `repo_scout(query)`.
-3. RepoTracer starts an isolated ephemeral thread through `codex app-server` using GPT-5.6 Luna at medium reasoning.
+3. RepoTracer starts an isolated ephemeral thread through `codex app-server` using GPT-5.6 Luna at medium reasoning. It carries over the active Codex model-provider settings, including compatible custom providers, without inheriting the rest of the Codex home.
 4. Luna can call only read-only repository tools. It receives bounded Read, Glob, and Grep results.
 5. RepoTracer validates every returned path and line range, then returns structured citations, source excerpts, and a handoff.
 6. Codex Sol reads the cited code and performs the edit.

--- a/crates/cli/src/subscription.rs
+++ b/crates/cli/src/subscription.rs
@@ -519,12 +519,18 @@ impl IsolatedCodexHome {
                         use std::os::unix::fs::PermissionsExt;
                         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700))?;
                     }
-                    let source = std::env::var_os("CODEX_HOME")
+                    let source_home = std::env::var_os("CODEX_HOME")
                         .map(PathBuf::from)
-                        .or_else(|| dirs::home_dir().map(|home| home.join(".codex")))
-                        .map(|home| home.join("auth.json"));
-                    if let Some(source) = source.filter(|source| source.is_file()) {
-                        link_auth(&source, &path.join("auth.json"))?;
+                        .or_else(|| dirs::home_dir().map(|home| home.join(".codex")));
+                    if let Some(source_home) = source_home {
+                        let auth = source_home.join("auth.json");
+                        if auth.is_file() {
+                            link_auth(&auth, &path.join("auth.json"))?;
+                        }
+                        write_provider_config(
+                            &source_home.join("config.toml"),
+                            &path.join("config.toml"),
+                        )?;
                     }
                     return Ok(Self { path });
                 }
@@ -557,6 +563,54 @@ fn link_auth(source: &Path, target: &Path) -> Result<()> {
     std::fs::copy(source, target)
         .map(|_| ())
         .with_context(|| "could not make Codex authentication available to isolated scout")
+}
+
+/// Keep the active Codex provider while excluding user MCPs, hooks, plugins,
+/// and other session settings from the isolated scout home.
+fn write_provider_config(source: &Path, target: &Path) -> Result<()> {
+    let text = match std::fs::read_to_string(source) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("could not read Codex config {}", source.display()))
+        }
+    };
+    let config: toml::Value = toml::from_str(&text)
+        .with_context(|| format!("could not parse Codex config {}", source.display()))?;
+    let config = config
+        .as_table()
+        .context("Codex config root must be a TOML table")?;
+    let mut child = toml::map::Map::new();
+
+    for key in ["model", "model_provider", "openai_base_url"] {
+        if let Some(value) = config.get(key) {
+            child.insert(key.into(), value.clone());
+        }
+    }
+
+    if let Some(provider_id) = config.get("model_provider").and_then(toml::Value::as_str) {
+        if let Some(provider) = config
+            .get("model_providers")
+            .and_then(toml::Value::as_table)
+            .and_then(|providers| providers.get(provider_id))
+        {
+            let mut providers = toml::map::Map::new();
+            providers.insert(provider_id.into(), provider.clone());
+            child.insert("model_providers".into(), toml::Value::Table(providers));
+        }
+    }
+
+    if child.is_empty() {
+        return Ok(());
+    }
+    std::fs::write(target, toml::to_string(&toml::Value::Table(child))?)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(target, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
 }
 
 fn truncate_utf8(text: &str, max_bytes: usize) -> String {
@@ -830,5 +884,60 @@ done
             .unwrap_err();
         assert!(error.to_string().contains("timed out"));
         assert!(started.elapsed() < Duration::from_secs(2));
+    }
+
+    #[test]
+    fn child_config_keeps_the_selected_provider_and_drops_user_tools() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("config.toml");
+        let target = dir.path().join("child-config.toml");
+        std::fs::write(
+            &source,
+            r#"
+model = "gpt-5.6-luna"
+model_provider = "codex-lb"
+openai_base_url = "https://ignored-for-custom-provider.example"
+
+[model_providers.codex-lb]
+name = "Codex LB"
+base_url = "https://codex-lb.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+
+[mcp_servers.secret]
+command = "do-not-copy"
+
+[hooks.SessionStart]
+hooks = []
+"#,
+        )
+        .unwrap();
+
+        write_provider_config(&source, &target).unwrap();
+        let child: toml::Value = toml::from_str(&std::fs::read_to_string(target).unwrap()).unwrap();
+        assert_eq!(child["model"].as_str(), Some("gpt-5.6-luna"));
+        assert_eq!(child["model_provider"].as_str(), Some("codex-lb"));
+        assert_eq!(
+            child["model_providers"]["codex-lb"]["base_url"].as_str(),
+            Some("https://codex-lb.example/v1")
+        );
+        assert!(child.get("mcp_servers").is_none());
+        assert!(child.get("hooks").is_none());
+    }
+
+    #[test]
+    fn child_config_preserves_the_builtin_openai_base_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("config.toml");
+        let target = dir.path().join("child-config.toml");
+        std::fs::write(&source, "openai_base_url = \"https://proxy.example/v1\"\n").unwrap();
+
+        write_provider_config(&source, &target).unwrap();
+        let child: toml::Value = toml::from_str(&std::fs::read_to_string(target).unwrap()).unwrap();
+        assert_eq!(
+            child["openai_base_url"].as_str(),
+            Some("https://proxy.example/v1")
+        );
+        assert!(child.get("model_providers").is_none());
     }
 }

--- a/crates/cli/src/subscription.rs
+++ b/crates/cli/src/subscription.rs
@@ -583,7 +583,12 @@ fn write_provider_config(source: &Path, target: &Path) -> Result<()> {
         .context("Codex config root must be a TOML table")?;
     let mut child = toml::map::Map::new();
 
-    for key in ["model", "model_provider", "openai_base_url"] {
+    for key in [
+        "model",
+        "model_provider",
+        "openai_base_url",
+        "cli_auth_credentials_store",
+    ] {
         if let Some(value) = config.get(key) {
             child.insert(key.into(), value.clone());
         }
@@ -897,6 +902,7 @@ done
 model = "gpt-5.6-luna"
 model_provider = "codex-lb"
 openai_base_url = "https://ignored-for-custom-provider.example"
+cli_auth_credentials_store = "keyring"
 
 [model_providers.codex-lb]
 name = "Codex LB"
@@ -917,6 +923,10 @@ hooks = []
         let child: toml::Value = toml::from_str(&std::fs::read_to_string(target).unwrap()).unwrap();
         assert_eq!(child["model"].as_str(), Some("gpt-5.6-luna"));
         assert_eq!(child["model_provider"].as_str(), Some("codex-lb"));
+        assert_eq!(
+            child["cli_auth_credentials_store"].as_str(),
+            Some("keyring")
+        );
         assert_eq!(
             child["model_providers"]["codex-lb"]["base_url"].as_str(),
             Some("https://codex-lb.example/v1")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,7 @@ Codex Sol
 
 ## Default Codex backend
 
-The default backend launches `codex app-server` over local stdio and creates an ephemeral GPT-5.6 Luna thread. A temporary Codex home exposes the existing authentication while excluding personal instructions, skills, hooks, plugins, and MCP servers from the scout.
+The default backend launches `codex app-server` over local stdio and creates an ephemeral GPT-5.6 Luna thread. A temporary Codex home exposes the current authentication and active model-provider settings while excluding personal instructions, skills, hooks, plugins, and MCP servers from the scout. RepoTracer rebuilds that small provider config for each scout, so provider changes are picked up without maintaining a second Codex installation.
 
 The child process receives:
 

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repotracer",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Get up to 60% more from your Codex limits. A cheaper model searches your repo so Codex stops burning turns on it.",
   "bin": {
     "repotracer": "bin/repotracer.js"


### PR DESCRIPTION
## What changed

- Check for RepoTracer updates on every MCP startup instead of once per day.
- Keep the isolated temporary `CODEX_HOME` boundary.
- Reuse the current `auth.json` and credential-store mode.
- Project the selected model/provider, built-in OpenAI base URL, and selected custom provider table into a minimal child config for every scout.
- Do not inherit user MCP servers, hooks, plugins, or other Codex state.
- Prepare Cargo and npm version `0.1.8` with changelog entries.

This supports providers such as `codex-lb` without sharing the full user `CODEX_HOME`.

## Verification

- `cargo fmt --check`
- `cargo test -p repotracer` (31 unit tests, 7 setup tests)
- `npm test --prefix packages/npm` (5 tests)
- Cargo/npm version parity at `0.1.8`
- Real `codex app-server` scout through the active `codex-lb` provider: one repository tool call, valid `Cargo.toml:13-14` citation, exit 0

Reference: https://learn.chatgpt.com/docs/config-file/config-reference