### PR TITLE
fix: detect only installed RepoTracer MCP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
-      - name: Test v0.1.9 upgrade
+      - name: Test v1.0.0 upgrade
         run: python3 scripts/test-version-upgrade.py
 
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.1 — 2026-08-30
+
+### Fixed
+- Setup no longer treats unrelated `repotracer` text left in Codex configuration as an installed MCP integration after uninstall
+
 ## 1.0.0 — 2026-08-30
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "repotracer"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "repotracer-bench"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "repotracer-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "repotracer-mcp"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "repotracer-model"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "repotracer-repo-tools"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 default-members = ["crates/cli"]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/repotracer/repotracer"

--- a/crates/cli/src/agents.rs
+++ b/crates/cli/src/agents.rs
@@ -53,7 +53,10 @@ fn detect_codex() -> AgentInfo {
 
 fn file_contains_repotracer(path: &Path) -> bool {
     fs::read_to_string(path)
-        .map(|s| s.contains("repotracer"))
+        .map(|text| {
+            text.lines()
+                .any(|line| line.trim() == "[mcp_servers.repotracer]")
+        })
         .unwrap_or(false)
 }
 
@@ -261,6 +264,21 @@ mod tests {
         assert_eq!(once, twice);
         assert_eq!(once.matches("[mcp_servers.repotracer]").count(), 1);
         assert!(once.contains("[other]"));
+    }
+
+    #[test]
+    fn uninstall_residue_is_not_a_configured_install() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let installed =
+            "model_provider = \"repotracer\"\n[mcp_servers.repotracer]\ncommand = \"repotracer\"\n";
+        fs::write(
+            &path,
+            remove_toml_section(installed, "[mcp_servers.repotracer]"),
+        )
+        .unwrap();
+
+        assert!(!file_contains_repotracer(&path));
     }
 
     #[test]

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repotracer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Get up to 60% more from your Codex limits. A cheaper model searches your repo so Codex stops burning turns on it.",
   "bin": {
     "repotracer": "bin/repotracer.js"

--- a/scripts/test-version-upgrade.py
+++ b/scripts/test-version-upgrade.py
@@ -61,8 +61,8 @@ def version(executable: Path, env: dict[str, str] | None = None) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--from-tag", default="v0.1.9")
-    parser.add_argument("--to-version", default="1.0.0")
+    parser.add_argument("--from-tag", default="v1.0.0")
+    parser.add_argument("--to-version", default="1.0.1")
     args = parser.parse_args()
 
     run("git", "rev-parse", "--verify", args.from_tag)


### PR DESCRIPTION
Fix setup's configured-state check to require the exact Codex MCP table, so unrelated RepoTracer residue left after uninstall no longer opens the update/uninstall menu. Includes the regression check and v1.0.1 release metadata.